### PR TITLE
BUG: Fixing errors

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   # d-SEAMS deps
   - yaml-cpp
   - boost-cpp
-  - fmt==9.0.0
+  - fmt==9.1.0
   - eigen==3.4.0
   # Python
   - pdm

--- a/pyb11_srcs/py_one.cc
+++ b/pyb11_srcs/py_one.cc
@@ -63,15 +63,15 @@ PYBIND11_MODULE(cyoda, m) {
     py::class_<molSys::Result>(m, "Result")
         .def(py::init<>())
         .def_readwrite("classifier", &molSys::Result::classifier)
-        .def_readwrite("c_value", &molSys::Result::c_value)
-        .def("__repr__",
-             [](const molSys::Result &self_C) {
+       .def_readwrite("c_value", &molSys::Result::c_value)
+       .def("__repr__",
+           [](const molSys::Result &self_C) {
                  std::uintptr_t ptr_val = std::uintptr_t(&self_C);
                  return fmt::format("<Result mem_loc:{:x}>", static_cast<uint>(ptr_val));
-             })
-        .def("__str__", [](const molSys::Result &self_C) {
-            return fmt::format("classifier: {} c_value: {}", self_C.classifier, self_C.c_value);
-        });
+             });
+//        .def("__str__", [](const molSys::Result &self_C) {
+//            return fmt::format("classifier: {} c_value: {}", self_C.classifier, self_C.c_value);
+//        });
 
     py::class_<molSys::PointCloud<molSys::Point<double>, double>>(m, "PointCloudDouble")
         .def(py::init<>())

--- a/subprojects/seams-core.wrap
+++ b/subprojects/seams-core.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory=seams-core
-url=https://github.com/d-SEAMS/seams-core
-revision=1b52b69b34041c15b266d35b4b653bea636810f1
+url=https://github.com/RuhiRG/seams-core
+revision=2196bc2b9c04c9ec8876c87a764a6fdf226e2272
 
 [provide]
 seams-core=git


### PR DESCRIPTION
while compiling the pyseams using docker, I saw the following:

1. The version of fmt was still 9.0.0 in pyseams.
    - I changed it to 9.1.0.
2. One of the python binding was erroring out.
    - I commented it out for now, will fix it later.
3. The seams-core.wrap file was linked to the older version of code which lead to compilation problem
   - I changed it to the newer version of code.